### PR TITLE
Add function curry test

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3,6 +3,12 @@ pub mod parser;
 use serde::Serialize;
 
 #[derive(Serialize, Debug, Clone)]
+pub struct Callable {
+    pub name: Box<Expr>,
+    pub args: Vec<Expr>,
+}
+
+#[derive(Serialize, Debug, Clone)]
 pub enum Expr {
     // Literal values
     Number(i32),
@@ -18,10 +24,7 @@ pub enum Expr {
         statement: Box<Expr>,
     },
 
-    FunctionCall {
-        name: String,
-        args: Vec<Expr>,
-    },
+    FunctionCall(Callable),
 
     // Binary operations: arithmetic, comparison, logical
     BinaryOp {

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -45,9 +45,13 @@ param            = { identifier ~ (":" ~ type_expr)? }
 param_list       = { param ~ ("," ~ param)* }
 function_literal = { "fn" ~ "(" ~ param_list? ~ ")" ~ (":" ~ type_expr)? ~ block }
 
-function_call = { identifier ~ "(" ~ arg_list? ~ ")" }
-arg_list      = { expr ~ ("," ~ expr)* }
-return_stmt   = { "return" ~ expr? }
+call_suffix   = { "(" ~ arg_list? ~ ")" }
+function_call = {
+    (identifier | "(" ~ expr ~ ")") ~ call_suffix+
+}
+
+arg_list    = { expr ~ ("," ~ expr)* }
+return_stmt = { "return" ~ expr? }
 
 // Primary expressions (atoms that cannot be broken down further)
 primary = _{


### PR DESCRIPTION
## What
Ensure support for function currying (as well as function chaining).
```
let foo = fn(a) {
  return fn(b) {
    return a + b;
  };
};

let addTen = foo(10);
let addFive = foo(5);

print(addTen(42)); // 52
print(addFive(42)); // 47
print(foo(2)(40)); // 42
```